### PR TITLE
Take IAM role name as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You can provide the script credentials using aws-vault
 
 ``` bash
 aws-vault exec identity -- python aws_ecr_scan_results.py \
+  --iam_role_name operator \
   --search use_an_lpa
 ```
 
@@ -31,6 +32,7 @@ to configure other options, use the additional arguments
 
 ``` bash
 aws-vault exec identity -- python aws_ecr_scan_results.py \
+  --iam_role_name operator
   --search use_an_lpa \
   --tag latest \
   --webhook "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" \

--- a/README.md
+++ b/README.md
@@ -25,14 +25,16 @@ You can provide the script credentials using aws-vault
 ``` bash
 aws-vault exec identity -- python aws_ecr_scan_results.py \
   --iam_role_name operator \
-  --search use_an_lpa
+  --ecr_aws_account_id 311462405659 \
+  --search online-lpa
 ```
 
 to configure other options, use the additional arguments
 
 ``` bash
 aws-vault exec identity -- python aws_ecr_scan_results.py \
-  --iam_role_name operator
+  --iam_role_name operator \
+  --ecr_aws_account_id 311462405659
   --search use_an_lpa \
   --tag latest \
   --webhook "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" \

--- a/aws_ecr_scan_results.py
+++ b/aws_ecr_scan_results.py
@@ -19,10 +19,10 @@ class ECRScanChecker:
     report = ''
     report_limit = ''
 
-    def __init__(self, iam_role_name, report_limit, search_term):
+    def __init__(self, iam_role_name, ecr_aws_account_id, report_limit, search_term):
         self.iam_role_name = iam_role_name
         self.report_limit = int(report_limit)
-        self.aws_account_id = 311462405659  # management account id
+        self.aws_account_id = ecr_aws_account_id
         self.set_iam_role_session()
         self.aws_ecr_client = boto3.client(
             'ecr',
@@ -158,8 +158,9 @@ def main():
     parser = argparse.ArgumentParser(
         description="Check ECR Scan results for all service container images.")
     parser.add_argument("--iam_role_name",
-                        default="operator",
-                        help="The root part of the ECR repositry path, for example online-lpa")
+                        help="Name of the iam role to use when creating AWS STS sessions")
+    parser.add_argument("--ecr_aws_account_id",
+                        help="AWS Account ID where ECR lives")
     parser.add_argument("--search",
                         default="",
                         help="The root part of the ECR repositry path, for example online-lpa")
@@ -177,7 +178,8 @@ def main():
                         help="Optionally turn off posting messages to slack")
 
     args = parser.parse_args()
-    work = ECRScanChecker(args.iam_role_name, args.result_limit, args.search)
+    work = ECRScanChecker(
+        args.iam_role_name, args.ecr_aws_account_id, args.result_limit, args.search)
     work.recursive_wait(args.tag)
     work.recursive_check_make_report(args.tag)
     work.finalise_report()

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,21 @@
+## Purpose
+
+_Briefly describe the purpose of the change, and/or link to the ticket for context_
+
+Fixes
+
+## Approach
+
+_Explain how your code addresses the purpose of the change_
+
+## Learning
+
+_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_
+
+## Checklist
+
+* [ ] I have performed a self-review of my own code
+* [ ] I have added relevant logging with appropriate levels to my code
+* [ ] I have updated documentation where relevant
+* [ ] I have added tests to prove my work
+* [ ] The product team have tested these changes


### PR DESCRIPTION
## Purpose

Allow other OPG projects to use this script
Make the script more useful when not posting to slack

## Approach

Make the IAM role name an argument that defaults to operator so other projects can provide their CI role name.
Split out the finalisation and printing of the ECR scan report
Always print the report, and post to slack when an slack webhook is present

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
