### PR TITLE
allow for description not to be present

### DIFF
--- a/aws_ecr_scan_results.py
+++ b/aws_ecr_scan_results.py
@@ -102,7 +102,11 @@ class ECRScanChecker:
 
                     for finding in findings["findings"]:
                         cve = finding["name"]
-                        description = finding["description"]
+
+                        description = "None"
+                        if "description" in finding:
+                            description = finding["description"]
+
                         severity = finding["severity"]
                         link = finding["uri"]
                         result = inspect.cleandoc("""*Image:* {0}


### PR DESCRIPTION
## Purpose

The description key may not always appear in the response from ECR.

## Approach
Assign a default of None to description, and override if a description is present in the response

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
